### PR TITLE
Change to custom fork of hdf5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "hdf5"
 version = "0.8.1"
-source = "git+https://github.com/mulimoen/hdf5-rust?branch=feature/chunks-iter#84fa692fc532c0c7e07435e66678f3eaea5b871f"
+source = "git+https://github.com/magnusuMET/hdf5-rust?branch=hidefix#038eb65aea4cc52cad26d176e3b17b796c749da3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -329,14 +329,14 @@ dependencies = [
  "lazy_static",
  "libc",
  "ndarray",
- "parking_lot",
+ "parking_lot 0.12.0",
  "paste",
 ]
 
 [[package]]
 name = "hdf5-derive"
 version = "0.8.1"
-source = "git+https://github.com/mulimoen/hdf5-rust?branch=feature/chunks-iter#84fa692fc532c0c7e07435e66678f3eaea5b871f"
+source = "git+https://github.com/magnusuMET/hdf5-rust?branch=hidefix#038eb65aea4cc52cad26d176e3b17b796c749da3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "hdf5-src"
 version = "0.8.1"
-source = "git+https://github.com/mulimoen/hdf5-rust?branch=feature/chunks-iter#84fa692fc532c0c7e07435e66678f3eaea5b871f"
+source = "git+https://github.com/magnusuMET/hdf5-rust?branch=hidefix#038eb65aea4cc52cad26d176e3b17b796c749da3"
 dependencies = [
  "cmake",
  "libz-sys",
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "hdf5-sys"
 version = "0.8.1"
-source = "git+https://github.com/mulimoen/hdf5-rust?branch=feature/chunks-iter#84fa692fc532c0c7e07435e66678f3eaea5b871f"
+source = "git+https://github.com/magnusuMET/hdf5-rust?branch=hidefix#038eb65aea4cc52cad26d176e3b17b796c749da3"
 dependencies = [
  "hdf5-src",
  "libc",
@@ -372,7 +372,7 @@ dependencies = [
 [[package]]
 name = "hdf5-types"
 version = "0.8.1"
-source = "git+https://github.com/mulimoen/hdf5-rust?branch=feature/chunks-iter#84fa692fc532c0c7e07435e66678f3eaea5b871f"
+source = "git+https://github.com/magnusuMET/hdf5-rust?branch=hidefix#038eb65aea4cc52cad26d176e3b17b796c749da3"
 dependencies = [
  "ascii",
  "cfg-if",
@@ -409,7 +409,6 @@ dependencies = [
  "itertools",
  "libc",
  "libdeflater",
- "libz-sys",
  "log",
  "lru",
  "ndarray",
@@ -499,7 +498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
 dependencies = [
  "cc",
- "cmake",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -675,7 +673,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -690,6 +698,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -919,7 +940,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1088,6 +1109,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,6 @@ hdf5-src = "0.8"
 log = "0.4"
 tokio-uring = "0.3.0"
 
-# Required because of deflate bug in 1.10
-libz-sys = { version = "1", features = ["zlib-ng"], default-features = false }
-
 [dependencies.serde]
 features = ["derive"]
 version = "1"
@@ -50,9 +47,9 @@ rayon = "1.5.0"
 sled = "0.34.6"
 
 [patch.crates-io]
-hdf5 = { git = "https://github.com/mulimoen/hdf5-rust", branch = "feature/chunks-iter" }
-hdf5-sys = { git = "https://github.com/mulimoen/hdf5-rust", branch = "feature/chunks-iter" }
-hdf5-src = { git = "https://github.com/mulimoen/hdf5-rust", branch = "feature/chunks-iter" }
+hdf5 = { git = "https://github.com/magnusuMET/hdf5-rust", branch = "hidefix" }
+hdf5-sys = { git = "https://github.com/magnusuMET/hdf5-rust", branch = "hidefix" }
+hdf5-src = { git = "https://github.com/magnusuMET/hdf5-rust", branch = "hidefix" }
 
 [features]
 default = ["static", "fast-index"]


### PR DESCRIPTION
This fork applies some fixes which are waiting for merge and vendors hdf5-c by copying the files and not using a git module. Since libgit2 does not support shallow clones, build times are outrageous since we have to pull the entire hdf5-c git tree 3 times per clean build