### PR TITLE
Index ncdf groups and subgroups

### DIFF
--- a/benches/large.rs
+++ b/benches/large.rs
@@ -8,8 +8,8 @@ use std::sync::Mutex;
 use hidefix::prelude::*;
 use ndarray::{s, IxDyn};
 
-const URL: &'static str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
-const VAR: &'static str = "u_eastward";
+const URL: &str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
+const VAR: &str = "u_eastward";
 
 type T = f32;
 
@@ -28,7 +28,7 @@ fn get_file() -> PathBuf {
 
     if !p.exists() {
         println!("downloading norkyst file to {p:#?}..");
-        std::fs::create_dir_all(&d).unwrap();
+        std::fs::create_dir_all(d).unwrap();
         let c = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(10 * 60))
             .build()
@@ -54,7 +54,7 @@ fn idx_small_slice(b: &mut Bencher) {
         .read_slice::<T, _, IxDyn>(s![0..2, 0..2, 0..1, 0..5])
         .unwrap()
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
 
     assert_eq!(
@@ -69,7 +69,7 @@ fn idx_small_slice(b: &mut Bencher) {
 #[bench]
 fn native_small_slice(b: &mut Bencher) {
     let p = get_file();
-    let h = hdf5::File::open(&p).unwrap();
+    let h = hdf5::File::open(p).unwrap();
     let d = h.dataset(VAR).unwrap();
 
     b.iter(|| {
@@ -94,7 +94,7 @@ fn idx_med_slice(b: &mut Bencher) {
         .read_slice::<T, _, IxDyn>(s![0..10, 0..10, 0..1, 0..700])
         .unwrap()
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
 
     assert_eq!(
@@ -115,7 +115,7 @@ fn idx_med_slice(b: &mut Bencher) {
 #[bench]
 fn native_med_slice(b: &mut Bencher) {
     let p = get_file();
-    let h = hdf5::File::open(&p).unwrap();
+    let h = hdf5::File::open(p).unwrap();
     let d = h.dataset(VAR).unwrap();
 
     b.iter(|| {
@@ -140,7 +140,7 @@ fn idx_big_slice(b: &mut Bencher) {
         .read_slice::<T, _, IxDyn>(s![0..24, 0..16, 0..1, 0..739])
         .unwrap()
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
 
     assert_eq!(
@@ -161,7 +161,7 @@ fn idx_big_slice(b: &mut Bencher) {
 #[bench]
 fn native_big_slice(b: &mut Bencher) {
     let p = get_file();
-    let h = hdf5::File::open(&p).unwrap();
+    let h = hdf5::File::open(p).unwrap();
     let d = h.dataset(VAR).unwrap();
 
     b.iter(|| {

--- a/benches/norkyst.rs
+++ b/benches/norkyst.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 
 use hidefix::prelude::*;
 
-const URL: &'static str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
+const URL: &str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
 
 fn get_file() -> PathBuf {
     use std::time::Duration;
@@ -24,7 +24,7 @@ fn get_file() -> PathBuf {
 
     if !p.exists() {
         println!("downloading norkyst file to {p:#?}..");
-        std::fs::create_dir_all(&d).unwrap();
+        std::fs::create_dir_all(d).unwrap();
         let c = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(10 * 60))
             .build()
@@ -50,7 +50,7 @@ fn idx_big_slice(b: &mut Bencher) {
 #[bench]
 fn native_big_slice(b: &mut Bencher) {
     let p = get_file();
-    let h = hdf5::File::open(&p).unwrap();
+    let h = hdf5::File::open(p).unwrap();
     let d = h.dataset("u_eastward").unwrap();
 
     b.iter(|| test::black_box(d.read_raw::<f32>().unwrap()))

--- a/examples/read_hfx_cache.rs
+++ b/examples/read_hfx_cache.rs
@@ -5,7 +5,7 @@ fn main() -> anyhow::Result<()> {
     let f = &args[1];
 
     println!("Indexing file: {f}..");
-    let i = Index::index(&f)?;
+    let i = Index::index(f)?;
 
     for var in &args[2..] {
         let mut r = i.reader(var).unwrap();

--- a/examples/read_hfx_parallel.rs
+++ b/examples/read_hfx_parallel.rs
@@ -6,7 +6,7 @@ fn main() -> anyhow::Result<()> {
     let f = &args[1];
 
     println!("Indexing file: {f}..");
-    let i = Index::index(&f)?;
+    let i = Index::index(f)?;
 
     for var in &args[2..] {
         let ds = i.dataset(var).unwrap();

--- a/examples/read_native_hdf5.rs
+++ b/examples/read_native_hdf5.rs
@@ -1,7 +1,7 @@
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let f = &args[1];
-    let h = hdf5::File::open(&f).unwrap();
+    let h = hdf5::File::open(f).unwrap();
 
     for var in &args[2..] {
         let d = h.dataset(var)?;

--- a/src/idx/chunk.rs
+++ b/src/idx/chunk.rs
@@ -419,12 +419,12 @@ mod tests {
                 10000 * std::mem::size_of::<Chunk<3>>() / std::mem::size_of::<u64>()
             );
 
-            let dechunks = Chunk::<3>::slice_from_u64s(&slice);
+            let dechunks = Chunk::<3>::slice_from_u64s(slice);
             assert_eq!(dechunks.len(), chunks.len());
             assert_eq!(dechunks, chunks.as_slice());
 
             b.iter(|| {
-                test::black_box(Chunk::<3>::slice_from_u64s(&slice));
+                test::black_box(Chunk::<3>::slice_from_u64s(slice));
             });
         }
     }

--- a/src/idx/dataset/mod.rs
+++ b/src/idx/dataset/mod.rs
@@ -58,8 +58,7 @@ mod tests {
     #[test]
     fn chunk_slice_11n() {
         let chunks = (0..2)
-            .map(|i| (0..32).map(move |j| Chunk::new(i * 32 + j * 1000, 635000, [i, j, 0])))
-            .flatten()
+            .flat_map(|i| (0..32).map(move |j| Chunk::new(i * 32 + j * 1000, 635000, [i, j, 0])))
             .collect::<Vec<_>>();
 
         let ds = Dataset::new(

--- a/src/idx/index.rs
+++ b/src/idx/index.rs
@@ -269,24 +269,18 @@ mod tests {
         let idx = Index::index(path).unwrap();
         assert_eq!(idx.datasets().len(), 1);
         assert_eq!(
-            idx.reader("x").unwrap().values::<f64>(None, None).unwrap(),
+            idx.reader("x").unwrap().values::<f64>(..).unwrap(),
             vec![1.0]
         );
         assert_eq!(idx.groups().len(), 1);
         assert_eq!(idx.group("a").unwrap().groups().len(), 1);
         assert_eq!(idx.group("a/b").unwrap().groups().len(), 1);
         assert_eq!(
-            idx.reader("a/b/x")
-                .unwrap()
-                .values::<f64>(None, None)
-                .unwrap(),
+            idx.reader("a/b/x").unwrap().values::<f64>(..).unwrap(),
             vec![1.0]
         );
         assert_eq!(
-            idx.reader("a/b/c/x")
-                .unwrap()
-                .values::<f64>(None, None)
-                .unwrap(),
+            idx.reader("a/b/c/x").unwrap().values::<f64>(..).unwrap(),
             vec![1.0]
         );
     }

--- a/src/idx/index.rs
+++ b/src/idx/index.rs
@@ -269,18 +269,18 @@ mod tests {
         let idx = Index::index(path).unwrap();
         assert_eq!(idx.datasets().len(), 1);
         assert_eq!(
-            idx.reader("x").unwrap().values::<f64>(..).unwrap(),
+            idx.reader("x").unwrap().values::<f64, _>(..).unwrap(),
             vec![1.0]
         );
         assert_eq!(idx.groups().len(), 1);
         assert_eq!(idx.group("a").unwrap().groups().len(), 1);
         assert_eq!(idx.group("a/b").unwrap().groups().len(), 1);
         assert_eq!(
-            idx.reader("a/b/x").unwrap().values::<f64>(..).unwrap(),
+            idx.reader("a/b/x").unwrap().values::<f64, _>(..).unwrap(),
             vec![1.0]
         );
         assert_eq!(
-            idx.reader("a/b/c/x").unwrap().values::<f64>(..).unwrap(),
+            idx.reader("a/b/c/x").unwrap().values::<f64, _>(..).unwrap(),
             vec![1.0]
         );
     }

--- a/src/idx/index.rs
+++ b/src/idx/index.rs
@@ -306,10 +306,10 @@ mod tests {
 
         println!("deserialize");
         let r = flexbuffers::Reader::get_root(s.view()).unwrap();
-        let mi = GroupIndex::deserialize(r).unwrap();
+        let mi = Index::deserialize(r).unwrap();
         println!("Deserialized Index: {:#?}", mi);
 
         let s = bincode::serialize(&i).unwrap();
-        bincode::deserialize::<GroupIndex>(&s).unwrap();
+        bincode::deserialize::<Index>(&s).unwrap();
     }
 }

--- a/src/idx/mod.rs
+++ b/src/idx/mod.rs
@@ -5,7 +5,7 @@ pub mod serde;
 
 pub use chunk::{Chunk, ULE};
 pub use dataset::{Dataset, DatasetD, DatasetExt, Datatype};
-pub use index::Index;
+pub use self::index::Index;
 
 /// Convenience trait for returning an index for an existing HDF5 file or dataset opened with
 /// the standard rust HDF5 library.

--- a/src/idx/mod.rs
+++ b/src/idx/mod.rs
@@ -3,9 +3,9 @@ mod dataset;
 mod index;
 pub mod serde;
 
+pub use self::index::Index;
 pub use chunk::{Chunk, ULE};
 pub use dataset::{Dataset, DatasetD, DatasetExt, Datatype};
-pub use self::index::Index;
 
 /// Convenience trait for returning an index for an existing HDF5 file or dataset opened with
 /// the standard rust HDF5 library.

--- a/src/idx/mod.rs
+++ b/src/idx/mod.rs
@@ -3,7 +3,7 @@ mod dataset;
 mod index;
 pub mod serde;
 
-pub use self::index::Index;
+pub use self::index::{GroupIndex, Index};
 pub use chunk::{Chunk, ULE};
 pub use dataset::{Dataset, DatasetD, DatasetExt, Datatype};
 

--- a/tests/read_dims.rs
+++ b/tests/read_dims.rs
@@ -26,7 +26,7 @@ fn chunked_2d() {
     let hval = hvs
         .slice(s![10..25, 10..25])
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
     assert_eq!(values, hval);
 }
@@ -51,7 +51,7 @@ fn chunked_3d() {
     let hval = hvs
         .slice(s![10..11, 10..12, 10..11])
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
     assert_eq!(values, hval);
 }
@@ -78,7 +78,7 @@ fn chunked_4d() {
     let hval = hvs
         .slice(s![10..25, 10..25, 10..25, 5..19])
         .iter()
-        .map(|v| *v)
+        .copied()
         .collect::<Vec<T>>();
     assert_eq!(values, hval);
 }

--- a/tests/read_norkyst.rs
+++ b/tests/read_norkyst.rs
@@ -7,7 +7,7 @@ use hidefix::prelude::*;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-const URL: &'static str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
+const URL: &str = "https://thredds.met.no/thredds/fileServer/fou-hi/norkyst800m-1h/NorKyst-800m_ZDEPTHS_his.an.2023081600.nc";
 
 fn get_file() -> PathBuf {
     use std::time::Duration;
@@ -24,7 +24,7 @@ fn get_file() -> PathBuf {
 
     if !p.exists() {
         println!("downloading norkyst file to {p:#?}..");
-        std::fs::create_dir_all(&d).unwrap();
+        std::fs::create_dir_all(d).unwrap();
         let c = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(10 * 60))
             .build()

--- a/tests/read_svim.rs
+++ b/tests/read_svim.rs
@@ -5,7 +5,7 @@ use futures::executor::block_on_stream;
 use futures::pin_mut;
 use hidefix::prelude::*;
 
-const SVIM: &'static str = "/home/gauteh/dev/dars/data/met/ocean_avg_19600101.nc4";
+const SVIM: &str = "/home/gauteh/dev/dars/data/met/ocean_avg_19600101.nc4";
 
 #[ignore]
 #[test]


### PR DESCRIPTION
This pull request focuses on the indexing of groups and subgroups within a NetCDF file. Below is a Rust example demonstrating the intended behavior:
```rust
let path = std::env::temp_dir().join("test_index_groups.nc");
// Create mock netcdf file
{
    let mut ncfile = netcdf::create(path.clone()).unwrap();
    ncfile.add_dimension("x", 1).unwrap();
    ncfile.add_variable::<f64>("x", &["x"]).unwrap().put_values(&[1.0], ..).unwrap();
    let mut ab = ncfile.add_group("a/b").unwrap();
    ab.add_dimension("x", 1).unwrap();
    ab.add_variable::<f64>("x", &["x"]).unwrap()put_values(&[1.0], ..).unwrap();
    let mut abc = ab.add_group("c").unwrap();
    abc.add_dimension("x", 1).unwrap();
    abc.add_variable::<f64>("x", &["x"]).unwrap().put_values(&[1.0], ..).unwrap();
}
let idx = Index::index(path).unwrap();
assert_eq!(idx.datasets.len(), 3);
assert!(idx.datasets.contains_key("x"));
assert!(idx.datasets.contains_key("a/b/x"));
assert!(idx.datasets.contains_key("a/b/c/x"));
```
Note: The dataset naming convention is designed to remain unchanged when indexing NetCDF file where only the root group is populated.