### PR TITLE
Add and use Extents type

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,8 @@ jobs:
           toolchain: '${{matrix.rust}}'
       - name: Build and test all crates
         run: cargo test -vv --workspace
+      - name: Build and test all docs
+        run: cargo test -vv --workspace --doc
       - name: Build examples
         run: cargo b --examples --verbose
 

--- a/benches/concurrency.rs
+++ b/benches/concurrency.rs
@@ -38,7 +38,7 @@ mod shuffled_compressed {
         b.iter(|| {
             for _ in 0..ITERATIONS {
                 for _ in 0..REPETITIONS {
-                    test::black_box(&r.values::<f32>(None, None).unwrap());
+                    test::black_box(&r.values::<f32, _>(..).unwrap());
                 }
             }
         })
@@ -56,7 +56,7 @@ mod shuffled_compressed {
         b.iter(|| {
             for _ in 0..ITERATIONS {
                 for _ in 0..REPETITIONS {
-                    test::black_box(&r.values_par::<f32>(None, None).unwrap());
+                    test::black_box(&r.values_par::<f32, _>(..).unwrap());
                 }
             }
         })
@@ -96,7 +96,7 @@ mod shuffled_compressed {
                     s.spawn(move |_| {
                         let mut r = i.reader("d_4_shufzip_chunks").unwrap();
                         for _ in 0..REPETITIONS {
-                            test::black_box(&r.values::<f32>(None, None).unwrap());
+                            test::black_box(&r.values::<f32, _>(..).unwrap());
                         }
                     });
                 }

--- a/benches/dataset.rs
+++ b/benches/dataset.rs
@@ -10,7 +10,7 @@ fn slicer(b: &mut Bencher) {
     let i = Index::index("tests/data/coads_climatology.nc4").unwrap();
     let d = i.dataset("SST").unwrap();
     if let DatasetD::D3(d) = d {
-        b.iter(|| d.chunk_slices(None, None).for_each(drop))
+        b.iter(|| d.chunk_slices(..).for_each(drop))
     } else {
         panic!()
     }

--- a/benches/large.rs
+++ b/benches/large.rs
@@ -59,16 +59,10 @@ fn idx_small_slice(b: &mut Bencher) {
 
     assert_eq!(
         hv,
-        r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[2, 2, 1, 5]))
-            .unwrap()
+        r.values::<T, _>((&[0, 0, 0, 0], &[2, 2, 1, 5])).unwrap()
     );
 
-    b.iter(|| {
-        test::black_box(
-            r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[2, 2, 1, 5]))
-                .unwrap(),
-        )
-    });
+    b.iter(|| test::black_box(r.values::<T, _>((&[0, 0, 0, 0], &[2, 2, 1, 5])).unwrap()));
 }
 
 #[ignore]
@@ -105,13 +99,13 @@ fn idx_med_slice(b: &mut Bencher) {
 
     assert_eq!(
         hv,
-        r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[10, 10, 1, 700]))
+        r.values::<T, _>((&[0, 0, 0, 0], &[10, 10, 1, 700]))
             .unwrap()
     );
 
     b.iter(|| {
         test::black_box(
-            r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[10, 10, 1, 2602]))
+            r.values::<T, _>((&[0, 0, 0, 0], &[10, 10, 1, 2602]))
                 .unwrap(),
         )
     });
@@ -151,13 +145,13 @@ fn idx_big_slice(b: &mut Bencher) {
 
     assert_eq!(
         hv,
-        r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[24, 16, 1, 739]))
+        r.values::<T, _>((&[0, 0, 0, 0], &[24, 16, 1, 739]))
             .unwrap()
     );
 
     b.iter(|| {
         test::black_box(
-            r.values::<T>(Some(&[0, 0, 0, 0]), Some(&[24, 16, 1, 2602]))
+            r.values::<T, _>((&[0, 0, 0, 0], &[24, 16, 1, 2602]))
                 .unwrap(),
         )
     });

--- a/benches/norkyst.rs
+++ b/benches/norkyst.rs
@@ -43,7 +43,7 @@ fn idx_big_slice(b: &mut Bencher) {
     let i = Index::index(&p).unwrap();
     let mut u = i.reader("u_eastward").unwrap();
 
-    b.iter(|| test::black_box(u.values::<f32>(None, None).unwrap()));
+    b.iter(|| test::black_box(u.values::<f32, _>(..).unwrap()));
 }
 
 #[ignore]

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -8,7 +8,7 @@ fn read_2d_chunked(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/chunked_oneD.h5").unwrap();
     let mut r = i.reader("d_4_chunks").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -16,7 +16,7 @@ fn read_2d_shuffled(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/chunked_shuffled_twoD.h5").unwrap();
     let mut r = i.reader("d_4_shuffled_chunks").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -24,7 +24,7 @@ fn read_2d_compressed(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/chunked_gzipped_twoD.h5").unwrap();
     let mut r = i.reader("d_4_gzipped_chunks").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -32,7 +32,7 @@ fn read_2d_shuffled_compressed(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/chunked_shufzip_twoD.h5").unwrap();
     let mut r = i.reader("d_4_shufzip_chunks").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -40,7 +40,7 @@ fn read_t_float32(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/t_float.h5").unwrap();
     let mut r = i.reader("d32_1").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -48,7 +48,7 @@ fn read_chunked_1d(b: &mut Bencher) {
     let i = Index::index("tests/data/dmrpp/chunked_oneD.h5").unwrap();
     let mut r = i.reader("d_4_chunks").unwrap();
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }
 
 #[bench]
@@ -62,9 +62,9 @@ fn coads(b: &mut Bencher) {
 
         assert_eq!(
             d.read_raw::<f32>().unwrap(),
-            r.values::<f32>(None, None).unwrap()
+            r.values::<f32, _>(..).unwrap()
         );
     }
 
-    b.iter(|| r.values::<f32>(None, None).unwrap())
+    b.iter(|| r.values::<f32, _>(..).unwrap())
 }

--- a/benches/stream.rs
+++ b/benches/stream.rs
@@ -19,7 +19,7 @@ fn chunked_1d_values(b: &mut Bencher) {
     let r = i.streamer("d_4_chunks").unwrap();
 
     b.iter(|| {
-        let v = r.stream_values::<f32>(None, None);
+        let v = r.stream_values::<f32, _>(..);
         consume_stream(&mut rt, v);
     })
 }
@@ -31,7 +31,7 @@ fn gzip_shuffle_2d_bytes(b: &mut Bencher) {
     let r = i.streamer("data").unwrap();
 
     b.iter(|| {
-        let v = r.stream(None, None);
+        let v = r.stream(&Extents::All);
         consume_stream(&mut rt, v);
     })
 }
@@ -43,7 +43,7 @@ fn coads_values(b: &mut Bencher) {
     let r = i.streamer("SST").unwrap();
 
     {
-        let v = r.stream_values::<f32>(None, None);
+        let v = r.stream_values::<f32, _>(..);
         let vs: Vec<f32> = block_on_stream(v).flatten().flatten().collect();
 
         let h = hdf5::File::open("tests/data/coads_climatology.nc4").unwrap();
@@ -52,7 +52,7 @@ fn coads_values(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        let v = r.stream_values::<f32>(None, None);
+        let v = r.stream_values::<f32, _>(..);
         consume_stream(&mut rt, v);
     })
 }
@@ -64,7 +64,7 @@ fn coads_bytes(b: &mut Bencher) {
     let r = i.streamer("SST").unwrap();
 
     b.iter(|| {
-        let v = r.stream(None, None);
+        let v = r.stream(&Extents::All);
         consume_stream(&mut rt, v);
     })
 }
@@ -81,7 +81,7 @@ fn coads_async_read(b: &mut Bencher) {
     b.iter(|| {
         block_on(async {
             let v = r
-                .stream(None, None)
+                .stream(&Extents::All)
                 .map_err(|_| std::io::ErrorKind::UnexpectedEof.into());
             let mut r = v.into_async_read();
             let mut buf = Vec::with_capacity(8 * 1024);

--- a/examples/read_hfx_cache.rs
+++ b/examples/read_hfx_cache.rs
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
         let mut r = i.reader(var).unwrap();
 
         println!("Reading values from {var}..");
-        let values = r.values::<f32>(None, None)?;
+        let values = r.values::<f32, _>(..)?;
 
         println!("Number of values: {}", values.len());
         println!("First value: {}", values.first().unwrap());

--- a/examples/read_hfx_concurrent.rs
+++ b/examples/read_hfx_concurrent.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
 
                 s.spawn(move |_| {
                     let mut r = i.reader(var).unwrap();
-                    let values = &r.values::<f32>(None, None).unwrap();
+                    let values = &r.values::<f32, _>(..).unwrap();
                     println!("Iteration: {}, Number of values: {}", ii, values.len());
                     println!(
                         "Iteration: {}, First value: {}",

--- a/examples/read_hfx_parallel.rs
+++ b/examples/read_hfx_parallel.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
 
         println!("Reading values from {var}..");
         // let values = r.values_par::<f32>(None, None).unwrap();
-        let values = r.values_dyn_par::<f32>(None, None).unwrap();
+        let values = r.values_dyn_par::<f32, _>(..).unwrap();
 
         println!("Number of values: {}", values.len());
         println!("First value: {}", values.first().unwrap());

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -473,13 +473,11 @@ mod ndarray_impl {
                         let start = u64::try_from(start)?;
                         if step != 1 {
                             Err(anyhow::anyhow!("Strides are not supported"))
+                        } else if let Some(end) = end {
+                            let end = u64::try_from(end)?;
+                            Ok(Extent::SliceEnd { start, end })
                         } else {
-                            if let Some(end) = end {
-                                let end = u64::try_from(end)?;
-                                Ok(Extent::SliceEnd { start, end })
-                            } else {
-                                Ok(Extent::Slice { start })
-                            }
+                            Ok(Extent::Slice { start })
                         }
                     }
                     SliceInfoElem::Index(index) => {

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -1,0 +1,686 @@
+//! Extents used for putting and getting data
+//! from a variable
+
+use std::convert::Infallible;
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+use anyhow::Result;
+
+#[derive(Debug, Clone, Copy)]
+/// An extent of a dimension
+///
+/// This enum has many ways to be constructed using `TryFrom`:
+/// ```rust
+/// # use hidefix::extent::Extent;
+/// fn take_extent(e: impl TryInto<Extent>) {}
+/// take_extent(3);
+/// take_extent(..);
+/// take_extent(..5);
+/// take_extent(..=5);
+/// take_extent(3..);
+/// // Start at 3 up to the 74th index
+/// take_extent(3..74);
+/// take_extent(3..=74);
+/// // Start at 3 with 74 elements
+/// take_extent((3, 74));
+/// ```
+pub enum Extent {
+    /// A slice
+    Slice {
+        /// Start of slice
+        start: u64,
+    },
+    /// A slice with a given end
+    SliceEnd {
+        /// Start of slice
+        start: u64,
+        /// End of slice
+        end: u64,
+    },
+    /// A slice with a given count
+    SliceCount {
+        /// Start of slice
+        start: u64,
+        /// Number of elements in slice
+        count: u64,
+    },
+    /// A slice which is just an index
+    Index(u64),
+}
+
+macro_rules! impl_for_ref {
+    ($from: ty : $item: ty) => {
+        impl From<&$from> for $item {
+            fn from(e: &$from) -> Self {
+                Self::from(e.clone())
+            }
+        }
+    };
+    (TryFrom $from: ty : $item: ty) => {
+        impl TryFrom<&$from> for $item {
+            type Error = anyhow::Error;
+            fn try_from(e: &$from) -> Result<Self, Self::Error> {
+                Self::try_from(e.clone())
+            }
+        }
+    };
+}
+
+impl From<u64> for Extent {
+    fn from(start: u64) -> Self {
+        Self::Index(start)
+    }
+}
+impl_for_ref!(u64: Extent);
+
+impl From<RangeFrom<u64>> for Extent {
+    fn from(range: RangeFrom<u64>) -> Self {
+        Self::Slice { start: range.start }
+    }
+}
+impl_for_ref!(RangeFrom<u64> : Extent);
+
+impl From<Range<u64>> for Extent {
+    fn from(range: Range<u64>) -> Self {
+        Self::SliceEnd {
+            start: range.start,
+            end: range.end,
+        }
+    }
+}
+impl_for_ref!(Range<u64> : Extent);
+
+impl From<RangeTo<u64>> for Extent {
+    fn from(range: RangeTo<u64>) -> Self {
+        Self::SliceEnd {
+            start: 0,
+            end: range.end,
+        }
+    }
+}
+impl_for_ref!(RangeTo<u64> : Extent);
+
+impl From<RangeToInclusive<u64>> for Extent {
+    fn from(range: RangeToInclusive<u64>) -> Self {
+        Self::SliceEnd {
+            start: 0,
+            end: range.end + 1,
+        }
+    }
+}
+impl_for_ref!(RangeToInclusive<u64> : Extent);
+
+impl From<RangeInclusive<u64>> for Extent {
+    fn from(range: RangeInclusive<u64>) -> Self {
+        Self::SliceEnd {
+            start: *range.start(),
+            end: range.end() + 1,
+        }
+    }
+}
+impl_for_ref!(RangeInclusive<u64> : Extent);
+
+impl From<RangeFull> for Extent {
+    fn from(_: RangeFull) -> Self {
+        Self::Slice { start: 0 }
+    }
+}
+impl_for_ref!(RangeFull: Extent);
+
+impl From<(u64, u64)> for Extent {
+    fn from((start, count): (u64, u64)) -> Self {
+        Self::SliceCount { start, count }
+    }
+}
+impl_for_ref!((u64, u64): Extent);
+
+#[derive(Debug, Clone, Default)]
+/// A selector for getting data in a dataset
+///
+/// This type can be constructed in many ways
+/// ```rust
+/// # use hidefix::extent::{Extent, Extents};
+/// fn take_extents(extents: impl TryInto<Extents>) {}
+/// // Get all values
+/// take_extents(..);
+/// // Get array with only first 10 of the first dimension
+/// // and the first 2 of the second dimension
+/// take_extents([..10, ..2]);
+/// // Get values after some index
+/// take_extents([1.., 2..]);
+/// // The above syntax (using arrays) does not allow arbitrary types
+/// // for each `Extent`, for this use tuples
+/// take_extents((
+///     1..10,
+///     (2..=100),
+///     4,
+///     (3, 4),
+/// ));
+/// // Or specify counts using slices of `Extent`
+/// take_extents([
+///     Extent::SliceCount { start: 0, count: 10 },
+///     (5..).into(),
+/// ]);
+/// // One can use two arrays to specify start and count separately
+/// take_extents((&[1, 2, 3], &[3, 2, 1]));
+/// // The `ndarray::s!` macro can also be used
+/// take_extents(ndarray::s![3, 5..]);
+/// ```
+pub enum Extents {
+    /// The full variable
+    #[default]
+    All,
+    /// A selection along each dimension
+    Extent(Vec<Extent>),
+}
+
+impl From<std::ops::RangeFull> for Extents {
+    fn from(_: std::ops::RangeFull) -> Self {
+        Self::All
+    }
+}
+
+impl From<Vec<Extent>> for Extents {
+    fn from(slice: Vec<Extent>) -> Self {
+        Self::Extent(slice)
+    }
+}
+
+impl From<&'_ [Extent]> for Extents {
+    fn from(slice: &[Extent]) -> Self {
+        Self::Extent(slice.to_owned())
+    }
+}
+
+impl<const N: usize> From<[Extent; N]> for Extents {
+    fn from(slice: [Extent; N]) -> Self {
+        Self::Extent(slice.to_vec())
+    }
+}
+
+macro_rules! impl_extent_as_extents {
+    ($item: ty) => {
+        impl From<$item> for Extents {
+            fn from(item: $item) -> Self {
+                Self::from(&item)
+            }
+        }
+
+        impl From<&$item> for Extents {
+            fn from(item: &$item) -> Self {
+                Self::Extent(vec![item.into()])
+            }
+        }
+    };
+    (TryFrom $item: ty) => {
+        impl TryFrom<$item> for Extents {
+            type Error = anyhow::Error;
+            fn try_from(item: $item) -> Result<Self, Self::Error> {
+                Ok(Self::Extent(vec![item.try_into()?]))
+            }
+        }
+        impl TryFrom<&$item> for Extents {
+            type Error = anyhow::Error;
+            fn try_from(item: &$item) -> Result<Self, Self::Error> {
+                Ok(Self::Extent(vec![item.clone().try_into()?]))
+            }
+        }
+    };
+}
+
+impl_extent_as_extents!(u64);
+impl_extent_as_extents!(RangeFrom<u64>);
+impl_extent_as_extents!(Range<u64>);
+impl_extent_as_extents!(RangeTo<u64>);
+impl_extent_as_extents!(RangeToInclusive<u64>);
+impl_extent_as_extents!(RangeInclusive<u64>);
+
+macro_rules! impl_extent_arrlike {
+    ($item: ty) => {
+        impl From<&'_ [$item]> for Extents {
+            fn from(slice: &[$item]) -> Self {
+                Self::Extent(slice.iter().map(|s| s.into()).collect())
+            }
+        }
+        impl From<Vec<$item>> for Extents {
+            fn from(slice: Vec<$item>) -> Self {
+                Self::from(slice.as_slice())
+            }
+        }
+
+        impl<const N: usize> From<[$item; N]> for Extents {
+            fn from(slice: [$item; N]) -> Self {
+                Self::from(slice.as_slice())
+            }
+        }
+        impl<const N: usize> From<&[$item; N]> for Extents {
+            fn from(slice: &[$item; N]) -> Self {
+                Self::from(slice.as_slice())
+            }
+        }
+    };
+    (TryFrom $item: ty) => {
+        impl TryFrom<&'_ [$item]> for Extents
+        //where <$item as TryInto<Extent>>::Error: Into<anyhow::Error>,
+        {
+            type Error = anyhow::Error;
+            fn try_from(slice: &[$item]) -> Result<Self, Self::Error> {
+                Ok(Self::Extent(
+                    slice
+                        .iter()
+                        .map(|s| {
+                            let extent: Extent = s.try_into()?;
+                            Ok(extent)
+                        })
+                        .collect::<Result<Vec<Extent>, anyhow::Error>>()?,
+                ))
+            }
+        }
+        impl TryFrom<Vec<$item>> for Extents {
+            type Error = anyhow::Error;
+            fn try_from(slice: Vec<$item>) -> Result<Self, Self::Error> {
+                Self::try_from(slice.as_slice())
+            }
+        }
+
+        impl<const N: u64> TryFrom<[$item; N]> for Extents {
+            type Error = anyhow::Error;
+            fn try_from(slice: [$item; N]) -> Result<Self, Self::Error> {
+                Self::try_from(slice.as_slice())
+            }
+        }
+        impl<const N: u64> TryFrom<&[$item; N]> for Extents {
+            type Error = anyhow::Error;
+            fn try_from(slice: &[$item; N]) -> Result<Self, Self::Error> {
+                Self::try_from(slice.as_slice())
+            }
+        }
+    };
+}
+
+impl_extent_arrlike!(u64);
+impl_extent_arrlike!(RangeFrom<u64>);
+impl_extent_arrlike!(Range<u64>);
+impl_extent_arrlike!(RangeTo<u64>);
+impl_extent_arrlike!(RangeToInclusive<u64>);
+impl_extent_arrlike!(RangeInclusive<u64>);
+impl_extent_arrlike!(RangeFull);
+impl_extent_arrlike!((u64, u64));
+
+macro_rules! impl_tuple {
+    () => ();
+
+    ($head:ident, $($tail:ident,)*) => (
+        #[allow(non_snake_case)]
+        impl<$head, $($tail,)*> TryFrom<($head, $($tail,)*)> for Extents
+            where
+                $head: TryInto<Extent>,
+                $head::Error: Into<anyhow::Error>,
+                $(
+                    $tail: TryInto<Extent>,
+                    $tail::Error: Into<anyhow::Error>,
+                )*
+        {
+            type Error = anyhow::Error;
+            fn try_from(slice: ($head, $($tail,)*)) -> Result<Self, Self::Error> {
+                let ($head, $($tail,)*) = slice;
+                Ok(vec![($head).try_into().map_err(|e| e.into())?, $(($tail).try_into().map_err(|e| e.into())?,)*].into())
+            }
+        }
+
+        impl_tuple! { $($tail,)* }
+    )
+}
+
+impl_tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, }
+
+impl From<()> for Extents {
+    fn from(_: ()) -> Self {
+        Self::Extent(vec![])
+    }
+}
+
+impl Extent {
+    /// Starting index
+    fn start(&self) -> u64 {
+        match *self {
+            Self::Index(idx) => idx,
+            Self::Slice { start }
+            | Self::SliceCount { start, count: _ }
+            | Self::SliceEnd { start, end: _ } => start,
+        }
+    }
+    /// Number of elements along this extent
+    fn count(&self) -> Option<u64> {
+        match *self {
+            Self::Index(_) => Some(1),
+            Self::Slice { start: _ } => None,
+            Self::SliceCount { start: _, count } => Some(count),
+            Self::SliceEnd { start, end } => Some((start..end).count() as u64),
+        }
+    }
+
+    /// Make into an `Extent` which has a known count
+    fn canonicalise(&self, dimsize: u64) -> Self {
+        match *self {
+            Self::Index(start) => Extent::Index(start),
+            Self::Slice { start } => Extent::SliceCount {
+                start,
+                count: (start..dimsize).count() as u64,
+            },
+            Self::SliceEnd { start, end } => Extent::SliceCount {
+                start,
+                count: (start..end).count() as u64,
+            },
+            Self::SliceCount { start, count } => Extent::SliceCount { start, count },
+        }
+    }
+}
+
+/// Iterator which creates canonicalised `Extent`s (where count is always `Some`)
+enum ExtentIterator<'a> {
+    All(std::slice::Iter<'a, u64>),
+    Extents(std::iter::Zip<std::slice::Iter<'a, Extent>, std::slice::Iter<'a, u64>>),
+}
+
+impl<'a> Iterator for ExtentIterator<'a> {
+    type Item = Extent;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::All(iter) => iter
+                .next()
+                .map(|&count| Extent::SliceCount { start: 0, count }),
+            Self::Extents(iter) => iter.next().map(|(&extent, &d)| extent.canonicalise(d)),
+        }
+    }
+}
+
+impl<'a> DoubleEndedIterator for ExtentIterator<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::All(iter) => iter
+                .next_back()
+                .map(|&count| Extent::SliceCount { start: 0, count }),
+            Self::Extents(iter) => iter.next_back().map(|(&extent, &d)| extent.canonicalise(d)),
+        }
+    }
+}
+
+pub(crate) type StartCount = (Vec<u64>, Vec<u64>);
+
+impl Extents {
+    /// Transform Extents into a series of `Extent` which all have a
+    /// `count` which returns `Some`
+    pub(crate) fn canonicalise<'a>(
+        &'a self,
+        dims: &'a [u64],
+    ) -> Result<impl DoubleEndedIterator<Item = Extent> + 'a, anyhow::Error> {
+        match self {
+            Extents::All => Ok(ExtentIterator::All(dims.iter())),
+            Extents::Extent(extents) => {
+                if extents.len() != dims.len() {
+                    return Err(anyhow::anyhow!(
+                        "Extents had length {} but dimension length is {}",
+                        extents.len(),
+                        dims.len(),
+                    ));
+                }
+                Ok(ExtentIterator::Extents(extents.iter().zip(dims.iter())))
+            }
+        }
+    }
+    /// Get sizes along the dims
+    pub(crate) fn get_counts<'a>(
+        &'a self,
+        dims: &'a [u64],
+    ) -> Result<impl Iterator<Item = u64> + 'a, anyhow::Error> {
+        Ok(self.canonicalise(dims)?.map(|e| e.count().unwrap()))
+    }
+    /// Get both starting index and sizes
+    pub(crate) fn get_start_count(&self, dims: &[u64]) -> Result<StartCount, anyhow::Error> {
+        Ok(self
+            .canonicalise(dims)?
+            .map(|e| (e.start(), e.count().unwrap()))
+            .unzip())
+    }
+    /// Same as `get_start_count`, but errors if `D` is not compatible
+    pub(crate) fn get_start_count_sized<const D: usize>(
+        &self,
+        dims: &[u64; D],
+    ) -> Result<([u64; D], [u64; D]), anyhow::Error> {
+        let (start, count) = self.get_start_count(dims)?;
+        anyhow::ensure!(start.len() == D, "shape is not compatible with extent");
+        Ok((start.try_into().unwrap(), count.try_into().unwrap()))
+    }
+}
+
+mod ndarray_impl {
+    use super::*;
+    use ndarray::{Dimension, SliceInfo, SliceInfoElem};
+
+    impl<T, Din: Dimension, Dout: Dimension> TryFrom<&'_ SliceInfo<T, Din, Dout>> for Extents
+    where
+        T: AsRef<[SliceInfoElem]>,
+    {
+        type Error = anyhow::Error;
+        fn try_from(slice: &SliceInfo<T, Din, Dout>) -> Result<Self, Self::Error> {
+            let slice: &[SliceInfoElem] = slice.as_ref();
+
+            Ok(slice
+                .iter()
+                .map(|&s| match s {
+                    SliceInfoElem::Slice { start, end, step } => {
+                        let start = u64::try_from(start)?;
+                        if step != 1 {
+                            Err(anyhow::anyhow!("Strides are not supported"))
+                        } else {
+                            if let Some(end) = end {
+                                let end = u64::try_from(end)?;
+                                Ok(Extent::SliceEnd { start, end })
+                            } else {
+                                Ok(Extent::Slice { start })
+                            }
+                        }
+                    }
+                    SliceInfoElem::Index(index) => {
+                        let index =
+                            u64::try_from(index).map_err(|_| anyhow::anyhow!("Invalid index"))?;
+                        Ok(Extent::Index(index))
+                    }
+                    SliceInfoElem::NewAxis => {
+                        Err(anyhow::anyhow!("Can't add new axis in this context"))
+                    }
+                })
+                .collect::<Result<Vec<Extent>, Self::Error>>()?
+                .into())
+        }
+    }
+
+    impl<T, Din: Dimension, Dout: Dimension> TryFrom<SliceInfo<T, Din, Dout>> for Extents
+    where
+        T: AsRef<[SliceInfoElem]>,
+    {
+        type Error = anyhow::Error;
+        fn try_from(slice: SliceInfo<T, Din, Dout>) -> Result<Self, Self::Error> {
+            Self::try_from(&slice)
+        }
+    }
+}
+
+impl TryFrom<(&[u64], &[u64])> for Extents {
+    type Error = anyhow::Error;
+    fn try_from((start, count): (&[u64], &[u64])) -> Result<Self, Self::Error> {
+        if start.len() == count.len() {
+            Ok(Self::Extent(
+                start
+                    .iter()
+                    .zip(count)
+                    .map(|(&start, &count)| Extent::SliceCount { start, count })
+                    .collect(),
+            ))
+        } else {
+            Err(anyhow::anyhow!(
+                "Indices and count does not have the same length"
+            ))
+        }
+    }
+}
+
+impl TryFrom<(Vec<u64>, Vec<u64>)> for Extents {
+    type Error = anyhow::Error;
+    fn try_from((start, count): (Vec<u64>, Vec<u64>)) -> Result<Self, Self::Error> {
+        Self::try_from((start.as_slice(), count.as_slice()))
+    }
+}
+
+macro_rules! impl_extents_for_arrays {
+    ($N: expr) => {
+        impl TryFrom<([u64; $N], [u64; $N])> for Extents {
+            type Error = Infallible;
+            fn try_from((start, count): ([u64; $N], [u64; $N])) -> Result<Self, Self::Error> {
+                    Self::try_from((&start, &count))
+            }
+        }
+
+        impl TryFrom<(&[u64; $N], &[u64; $N])> for Extents {
+            type Error = Infallible;
+            fn try_from((start, count): (&[u64; $N], &[u64; $N])) -> Result<Self, Self::Error> {
+                    Ok(Self::Extent(
+                        start
+                            .iter()
+                            .zip(count)
+                            .map(|(&start, &count)| Extent::SliceCount {
+                                start,
+                                count,
+                            })
+                            .collect(),
+                    ))
+            }
+        }
+    };
+    ($($N: expr,)*) => {
+        $(impl_extents_for_arrays! { $N })*
+    };
+}
+impl_extents_for_arrays! { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+
+impl From<&Self> for Extents {
+    fn from(extents: &Self) -> Self {
+        extents.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Extent, Extents};
+    use anyhow::Result;
+    fn take_extent<E>(e: E) -> Result<Extent>
+    where
+        E: TryInto<Extent>,
+        E::Error: Into<anyhow::Error>,
+    {
+        e.try_into().map_err(|e| e.into())
+    }
+
+    fn take_extents<E>(e: E) -> Result<Extents>
+    where
+        E: TryInto<Extents>,
+        E::Error: Into<anyhow::Error>,
+    {
+        e.try_into().map_err(|e| e.into())
+    }
+
+    #[test]
+    fn test_extent() -> Result<()> {
+        let _ = take_extent(1)?;
+        let _ = take_extent(1..)?;
+        let _ = take_extent(1..5)?;
+        let _ = take_extent(..5)?;
+        let _ = take_extent(..=5)?;
+        let _ = take_extent(4..=5)?;
+
+        // start+count
+        let _ = take_extent((5, 4))?;
+
+        // Empty slice
+        let _ = take_extent(1..0)?;
+        let _ = take_extent(1..=1)?;
+        let _ = take_extent(1..=2)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_extents() -> Result<()> {
+        // This is the "All" type
+        let extent = take_extents(..)?;
+        match extent {
+            Extents::All => {}
+            _ => panic!(),
+        }
+
+        // These are for 1D specs
+        let _ = take_extents(1)?;
+        let _ = take_extents(1..)?;
+        let _ = take_extents(1..5)?;
+        let _ = take_extents(..5)?;
+        let _ = take_extents(..=5)?;
+        let _ = take_extents(4..=5)?;
+
+        // These are multidimensional
+
+        // Array
+        let _ = take_extents([.., ..])?;
+        let _ = take_extents([1, 2])?;
+        let _ = take_extents([1.., 2..])?;
+        let _ = take_extents([1..5, 2..6])?;
+        let _ = take_extents([..5, ..6])?;
+        let _ = take_extents([..=5, ..=6])?;
+        let _ = take_extents([4..=50, 5..=8])?;
+
+        // Slice
+        let _ = take_extents([.., ..].as_slice())?;
+        let _ = take_extents([1, 2].as_slice())?;
+        let _ = take_extents([1.., 2..].as_slice())?;
+        let _ = take_extents([1..5, 2..6].as_slice())?;
+        let _ = take_extents([..5, ..6].as_slice())?;
+        let _ = take_extents([..=5, ..=6].as_slice())?;
+        let _ = take_extents([4..=5, 5..=6].as_slice())?;
+
+        // Vec
+        let _ = take_extents(vec![.., ..])?;
+        let _ = take_extents(vec![1, 2])?;
+        let _ = take_extents(vec![1.., 2..])?;
+        let _ = take_extents(vec![1..5, 2..6])?;
+        let _ = take_extents(vec![..5, ..6])?;
+        let _ = take_extents(vec![..=5, ..=6])?;
+        let _ = take_extents(vec![4..=5, 5..=6])?;
+
+        // Tuple
+        let _ = take_extents((1_u64.., 2_u64))?;
+        let _ = take_extents((1.., 2))?;
+        let _ = take_extents((1.., 2, ..6))?;
+
+        let _ = take_extents(ndarray::s![2..5, 4])?;
+        let _ = take_extents(ndarray::s![2..;4, 4]).unwrap_err();
+
+        // (start, count)
+        let _ = take_extents(([1, 2], [3, 4]))?;
+        let _ = take_extents(([1, 2].as_slice(), [3, 4].as_slice()))?;
+        let _ = take_extents((&[1, 2], &[3, 4]))?;
+        let _ = take_extents((vec![1, 2], vec![3, 4]))?;
+
+        // [(s0, c0), (s1, c1)]
+        let _ = take_extents([(1, 2), (3, 4)])?;
+        let _ = take_extents([(1, 2), (3, 4)].as_slice())?;
+        let _ = take_extents(&[(1, 2), (3, 4)])?;
+        let _ = take_extents(vec![(1, 2), (3, 4)])?;
+
+        // Use of borrowed Extents
+        let e: Extents = (..).into();
+        let _ = take_extents(&e)?;
+        let _ = take_extents(e)?;
+
+        Ok(())
+    }
+}

--- a/src/filters/gzip.rs
+++ b/src/filters/gzip.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use libdeflater::Decompressor;
 
 /// Helper to decompress a gzipped slice of `u8`s to another buffer of `u8`s.

--- a/src/idx/dataset/mod.rs
+++ b/src/idx/dataset/mod.rs
@@ -51,8 +51,8 @@ mod tests {
         )
         .unwrap();
 
-        ds.chunk_slices(None, None).for_each(drop);
-        ds.chunk_slices(None, Some(&[4])).for_each(drop);
+        ds.chunk_slices(..).for_each(drop);
+        ds.chunk_slices((&[0], &[4])).for_each(drop);
     }
 
     #[test]
@@ -75,27 +75,27 @@ mod tests {
 
         // ds.chunk_slices(None, Some(&[2, 4, 580, 1202]))
         //     .for_each(drop);
-        ds.chunk_slices(None, Some(&[2, 32, 580])).for_each(drop);
+        ds.chunk_slices((&[0, 0, 0], &[2, 32, 580])).for_each(drop);
     }
 
     #[test]
     fn chunk_slice_zero_count() {
         let d = test_dataset();
-        assert_eq!(d.chunk_slices(None, Some(&[1, 0])).next(), None);
+        assert_eq!(d.chunk_slices((&[0, 0], &[1, 0])).next(), None);
     }
 
     #[bench]
     fn chunk_slices_range(b: &mut Bencher) {
         let d = test_dataset();
 
-        b.iter(|| d.chunk_slices(None, None).for_each(drop));
+        b.iter(|| d.chunk_slices(..).for_each(drop));
     }
 
     #[bench]
     fn make_chunk_slices_iterator(b: &mut Bencher) {
         let d = test_dataset();
 
-        b.iter(|| test::black_box(d.chunk_slices(None, None)))
+        b.iter(|| test::black_box(d.chunk_slices(..)))
     }
 
     #[bench]
@@ -136,31 +136,31 @@ mod tests {
         let d = test_dataset();
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 0]), Some(&[1, 10]))
+            d.chunk_slices((&[0, 0], &[1, 10]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 0, 10)]
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 0]), Some(&[1, 20]))
+            d.chunk_slices((&[0, 0], &[1, 20]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 0, 10), (&d.chunks[1], 0, 10)]
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 5]), Some(&[1, 15]))
+            d.chunk_slices((&[0, 5], &[1, 15]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 5, 10), (&d.chunks[1], 0, 10)]
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 0]), Some(&[2, 10]))
+            d.chunk_slices((&[0, 0], &[2, 10]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 0, 20)]
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 5]), Some(&[2, 10]))
+            d.chunk_slices((&[0, 5], &[2, 10]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [
                 (&d.chunks[0], 5, 10),
@@ -171,7 +171,7 @@ mod tests {
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[0, 0]), Some(&[2, 20]))
+            d.chunk_slices((&[0, 0], &[2, 20]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [
                 (&d.chunks[0], 0, 10),
@@ -182,20 +182,20 @@ mod tests {
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[2, 0]), Some(&[1, 10]))
+            d.chunk_slices((&[2, 0], &[1, 10]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 20, 30),]
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[2, 5]), Some(&[1, 10]))
+            d.chunk_slices((&[2, 5], &[1, 10]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [(&d.chunks[0], 25, 30), (&d.chunks[1], 20, 25),]
         );
 
         // column
         assert_eq!(
-            d.chunk_slices(Some(&[2, 5]), Some(&[4, 1]))
+            d.chunk_slices((&[2, 5], &[4, 1]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [
                 (&d.chunks[0], 25, 26),
@@ -206,7 +206,7 @@ mod tests {
         );
 
         assert_eq!(
-            d.chunk_slices(Some(&[2, 15]), Some(&[4, 1]))
+            d.chunk_slices(([2_u64, 15], [4_u64, 1]))
                 .collect::<Vec<(&Chunk<2>, u64, u64)>>(),
             [
                 (&d.chunks[1], 25, 26),
@@ -342,7 +342,7 @@ mod tests {
         let i = Index::index("tests/data/coads_climatology.nc4").unwrap();
         let d = i.dataset("SST").unwrap();
         if let DatasetD::D3(d) = d {
-            let sliced = d.chunk_slices(None, None).collect::<Vec<_>>();
+            let sliced = d.chunk_slices(..).collect::<Vec<_>>();
             println!("slices: {:#?}", sliced);
 
             assert_eq!(sliced, slicebr);

--- a/src/idx/index.rs
+++ b/src/idx/index.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -145,7 +146,7 @@ mod tests {
         let hf = hdf5::File::open("tests/data/coads_climatology.nc4").unwrap();
         let i: Index = (&hf).try_into().unwrap();
         let mut r = i.reader("SST").unwrap();
-        r.values::<f32>(None, None).unwrap();
+        r.values::<f32, _>(..).unwrap();
     }
 
     #[test]
@@ -156,7 +157,7 @@ mod tests {
         let f = netcdf::open("tests/data/coads_climatology.nc4").unwrap();
         let i: Index = (&f).try_into().unwrap();
         let mut r = i.reader("SST").unwrap();
-        let iv = r.values::<f32>(None, None).unwrap();
+        let iv = r.values::<f32, _>(..).unwrap();
 
         let nv = f.variable("SST").unwrap().values::<f32, _>(..).unwrap();
 
@@ -170,7 +171,7 @@ mod tests {
         let p = PathBuf::from("tests/data/coads_climatology.nc4");
         let i: Index = p.as_path().try_into().unwrap();
         let mut r = i.reader("SST").unwrap();
-        r.values::<f32>(None, None).unwrap();
+        r.values::<f32, _>(..).unwrap();
     }
 
     #[test]

--- a/src/idx/mod.rs
+++ b/src/idx/mod.rs
@@ -17,7 +17,7 @@ pub use index::Index;
 /// let idx = hf.index().unwrap();
 ///
 /// let mut r = idx.reader("SST").unwrap();
-/// let values = r.values::<f32>(None, None).unwrap();
+/// let values = r.values::<f32, _>(..).unwrap();
 ///
 /// println!("SST: {:?}", values);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! let idx = Index::index("tests/data/coads_climatology.nc4").unwrap();
 //! let mut r = idx.reader("SST").unwrap();
 //!
-//! let values = r.values::<f32>(None, None).unwrap();
+//! let values = r.values::<f32, _>(..).unwrap();
 //!
 //! println!("SST: {:?}", values);
 //! ```
@@ -38,7 +38,7 @@
 //! use hidefix::prelude::*;
 //!
 //! let i = hdf5::File::open("tests/data/coads_climatology.nc4").unwrap().index().unwrap();
-//! let iv = i.reader("SST").unwrap().values::<f32>(None, None).unwrap();
+//! let iv = i.reader("SST").unwrap().values::<f32, _>(..).unwrap();
 //! ```
 //!
 //! ## NetCDF4 files
@@ -55,7 +55,7 @@
 //! let nv = f.variable("SST").unwrap().values::<f32, _>(..).unwrap();
 //!
 //! let i: Index = (&f).try_into().unwrap();
-//! let iv = i.reader("SST").unwrap().values::<f32>(None, None).unwrap();
+//! let iv = i.reader("SST").unwrap().values::<f32, _>(..).unwrap();
 //!
 //! assert_eq!(iv, nv);
 //! ```
@@ -66,7 +66,7 @@
 //! use hidefix::prelude::*;
 //!
 //! let i = netcdf::open("tests/data/coads_climatology.nc4").unwrap().index().unwrap();
-//! let iv = i.reader("SST").unwrap().values::<f32>(None, None).unwrap();
+//! let iv = i.reader("SST").unwrap().values::<f32, _>(..).unwrap();
 //! ```
 //!
 //! It is also possible to [stream](reader::stream::StreamReader) the values. The streamer is
@@ -95,19 +95,16 @@
 #![feature(slice_group_by)]
 #![feature(mutex_unlock)]
 #![feature(new_uninit)]
+
 extern crate test;
 
-#[macro_use]
-extern crate anyhow;
-
-#[macro_use]
-extern crate log;
-
+pub mod extent;
 pub mod filters;
 pub mod idx;
 pub mod reader;
 
 pub mod prelude {
+    pub use super::extent::{Extent, Extents};
     pub use super::idx::{DatasetExt, Datatype, Index, IntoIndex};
     pub use super::reader::{ParReader, ParReaderExt, Reader, ReaderExt, Streamer, StreamerExt};
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -97,7 +97,7 @@ impl Dataset {
 
         py.allow_threads(|| {
             let r = ds.as_par_reader(&self.idx.path().unwrap())?;
-            r.values_to_par(Some(indices), Some(counts), dst)
+            r.values_to_par((indices, counts), dst)
         })?;
 
         Ok(a.as_ref())
@@ -117,7 +117,7 @@ impl Dataset {
     {
         let a = py.allow_threads(|| {
             let r = ds.as_par_reader(&self.idx.path().unwrap())?;
-            r.values_dyn_par(Some(indices), Some(counts))
+            r.values_dyn_par((indices, counts))
         })?;
 
         let a = a.into_pyarray(py);

--- a/tests/read_dims.rs
+++ b/tests/read_dims.rs
@@ -13,7 +13,7 @@ fn chunked_2d() {
     let i = Index::index("tests/data/dmrpp/chunked_twoD.h5").unwrap();
     let mut r = i.reader("d_4_chunks").unwrap();
 
-    let values = r.values::<T>(None, None).unwrap();
+    let values = r.values::<T, _>(..).unwrap();
 
     let h = hdf5::File::open("tests/data/dmrpp/chunked_twoD.h5").unwrap();
     let d = h.dataset("d_4_chunks").unwrap();
@@ -21,7 +21,7 @@ fn chunked_2d() {
 
     assert_eq!(values, hval);
 
-    let values = r.values::<T>(Some(&[10, 10]), Some(&[15, 15])).unwrap();
+    let values = r.values::<T, _>((&[10, 10], &[15, 15])).unwrap();
     let hvs = d.read_dyn::<T>().unwrap();
     let hval = hvs
         .slice(s![10..25, 10..25])
@@ -38,7 +38,7 @@ fn chunked_3d() {
     let i = Index::index("tests/data/dmrpp/chunked_threeD.h5").unwrap();
     let mut r = i.reader("d_8_chunks").unwrap();
 
-    let values = r.values::<T>(None, None).unwrap();
+    let values = r.values::<T, _>(..).unwrap();
 
     let h = hdf5::File::open("tests/data/dmrpp/chunked_threeD.h5").unwrap();
     let d = h.dataset("d_8_chunks").unwrap();
@@ -46,9 +46,7 @@ fn chunked_3d() {
 
     assert_eq!(values, hval);
 
-    let values = r
-        .values::<T>(Some(&[10, 10, 10]), Some(&[1, 2, 1]))
-        .unwrap();
+    let values = r.values::<T, _>((&[10, 10, 10], &[1, 2, 1])).unwrap();
     let hvs = d.read_dyn::<T>().unwrap();
     let hval = hvs
         .slice(s![10..11, 10..12, 10..11])
@@ -65,7 +63,7 @@ fn chunked_4d() {
     let i = Index::index("tests/data/dmrpp/chunked_fourD.h5").unwrap();
     let mut r = i.reader("d_16_chunks").unwrap();
 
-    let values = r.values::<T>(None, None).unwrap();
+    let values = r.values::<T, _>(..).unwrap();
 
     let h = hdf5::File::open("tests/data/dmrpp/chunked_fourD.h5").unwrap();
     let d = h.dataset("d_16_chunks").unwrap();
@@ -74,7 +72,7 @@ fn chunked_4d() {
     assert_eq!(values, hval);
 
     let values = r
-        .values::<T>(Some(&[10, 10, 10, 5]), Some(&[15, 15, 15, 14]))
+        .values::<T, _>((&[10, 10, 10, 5], &[15, 15, 15, 14]))
         .unwrap();
     let hvs = d.read_dyn::<T>().unwrap();
     let hval = hvs
@@ -92,7 +90,7 @@ fn scalar() {
     let i = Index::index("tests/data/dmrpp/t_int_scalar.h5").unwrap();
     let mut r = i.reader("scalar").unwrap();
 
-    let values = r.values::<T>(None, None).unwrap();
+    let values = r.values::<T, _>(..).unwrap();
 
     let h = hdf5::File::open("tests/data/dmrpp/t_int_scalar.h5").unwrap();
     let d = h.dataset("scalar").unwrap();

--- a/tests/read_double.rs
+++ b/tests/read_double.rs
@@ -15,21 +15,21 @@ fn feb_nc4_double() {
     let d = h.dataset("T").unwrap();
     let hv = d.read_raw::<f64>().unwrap();
 
-    let v = r.values::<f64>(None, None).unwrap();
+    let v = r.values::<f64, _>(..).unwrap();
 
     assert_eq!(hv, v);
 
     println!("{:?}", v);
 
     let r = i.streamer("T").unwrap();
-    let s = r.stream_values::<f64>(None, None);
+    let s = r.stream_values::<f64, _>(..);
     pin_mut!(s);
     let vs: Vec<f64> = block_on_stream(s).flatten().flatten().collect();
 
     assert_eq!(hv, vs);
     println!("{:?}", vs);
 
-    let sb = r.stream(None, None);
+    let sb = r.stream(&Extents::All);
     pin_mut!(sb);
     let mut vb: Vec<u8> = block_on_stream(sb).flatten().flatten().collect();
 

--- a/tests/read_norkyst.rs
+++ b/tests/read_norkyst.rs
@@ -46,8 +46,8 @@ fn coords() {
     let X = h.dataset("X").unwrap().read_raw::<f64>().unwrap();
 
     let hi = Index::index(&p).unwrap();
-    let hY = hi.reader("Y").unwrap().values::<f64>(None, None).unwrap();
-    let hX = hi.reader("X").unwrap().values::<f64>(None, None).unwrap();
+    let hY = hi.reader("Y").unwrap().values::<f64, _>(..).unwrap();
+    let hX = hi.reader("X").unwrap().values::<f64, _>(..).unwrap();
 
     assert_eq!(Y, hY);
     assert_eq!(X, hX);
@@ -63,16 +63,8 @@ fn wind() {
     let Vw = h.dataset("Vwind").unwrap().read_raw::<f32>().unwrap();
 
     let hi = Index::index(&p).unwrap();
-    let hUw = hi
-        .reader("Uwind")
-        .unwrap()
-        .values::<f32>(None, None)
-        .unwrap();
-    let hVw = hi
-        .reader("Vwind")
-        .unwrap()
-        .values::<f32>(None, None)
-        .unwrap();
+    let hUw = hi.reader("Uwind").unwrap().values::<f32, _>(..).unwrap();
+    let hVw = hi.reader("Vwind").unwrap().values::<f32, _>(..).unwrap();
 
     hi.dataset("Uwind").unwrap().valid().unwrap();
 
@@ -100,12 +92,12 @@ fn current() {
     let hu = hi
         .reader("u_eastward")
         .unwrap()
-        .values::<f32>(None, None)
+        .values::<f32, _>(..)
         .unwrap();
     let hv = hi
         .reader("v_northward")
         .unwrap()
-        .values::<f32>(None, None)
+        .values::<f32, _>(..)
         .unwrap();
 
     assert_eq!(u, hu);
@@ -125,13 +117,9 @@ fn temperature_salinity() {
     let hUw = hi
         .reader("temperature")
         .unwrap()
-        .values::<i16>(None, None)
+        .values::<i16, _>(..)
         .unwrap();
-    let hVw = hi
-        .reader("salinity")
-        .unwrap()
-        .values::<i16>(None, None)
-        .unwrap();
+    let hVw = hi.reader("salinity").unwrap().values::<i16, _>(..).unwrap();
 
     assert_eq!(Uw, hUw);
     assert_eq!(Vw, hVw);
@@ -145,7 +133,7 @@ fn chunk_slice_fracture() {
 
     // test that chunks are not unnecessarily fractured
     fn test_slices<const D: usize>(ds: &Dataset<D>) {
-        let chunks = ds.chunk_slices(None, None).collect::<Vec<_>>();
+        let chunks = ds.chunk_slices(..).collect::<Vec<_>>();
 
         println!("ds chunks: {}", ds.chunks.len());
         println!("chunk slice len: {}", chunks.len());

--- a/tests/read_strings.rs
+++ b/tests/read_strings.rs
@@ -10,7 +10,7 @@ fn chunked_string_array() {
     let i = Index::index("tests/data/dmrpp/chunked_string_array.h5").unwrap();
     let mut r = i.reader("string_array").unwrap();
 
-    let values = r.values::<T>(None, None).unwrap();
+    let values = r.values::<T, _>(..).unwrap();
     let strs = std::str::from_utf8(&values).unwrap();
     println!("{:?}", strs);
 

--- a/tests/read_svim.rs
+++ b/tests/read_svim.rs
@@ -18,7 +18,7 @@ fn ocean_time() {
 
     let i = h.index().unwrap();
     let mut d = i.reader("ocean_time").unwrap();
-    let v = d.values::<f64>(None, None).unwrap();
+    let v = d.values::<f64, _>(..).unwrap();
 
     assert_eq!(hv, v);
 
@@ -30,7 +30,7 @@ fn ocean_time() {
     }
 
     let s = i.streamer("ocean_time").unwrap();
-    let s = s.stream_values::<f64>(None, None);
+    let s = s.stream_values::<f64, _>(..);
     pin_mut!(s);
     let vs: Vec<f64> = block_on_stream(s).flatten().flatten().collect();
 
@@ -60,14 +60,14 @@ fn temp() {
     let mut d = i.reader("temp").unwrap();
     assert_eq!(d.dsize(), 2);
 
-    let v = d.values::<i16>(None, None).unwrap();
+    let v = d.values::<i16, _>(..).unwrap();
     assert_eq!(hv, v);
 
-    d.values::<i16>(Some(&[0, 0, 0, 0]), Some(&[1, 32, 580, 1202]))
+    d.values::<i16, _>((&[0, 0, 0, 0], &[1, 32, 580, 1202]))
         .unwrap();
 
     let s = i.streamer("temp").unwrap();
-    let s = s.stream_values::<i16>(None, None);
+    let s = s.stream_values::<i16, _>(..);
     pin_mut!(s);
     let vs: Vec<i16> = block_on_stream(s).flatten().flatten().collect();
     assert_eq!(hv, vs);


### PR DESCRIPTION
Adds the Extents type which should make selecting data a bit more ergonomic.

This mirrors the API of the netcdf and hdf5 crates (more or less copy-paste ;) ) but is tailored to the assumptions of this crate (i.e. no strides).

This contains major breaking API changes.