### PR TITLE
Update Cargo.toml license metadata to MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Gaute Hope <eg@gaute.vetsj.com>"]
 edition = "2021"
 keywords = ["hdf", "async", "concurrency"]
-license = "LGPL-3.0-or-later"
+license = "MIT"
 name = "hidefix"
 repository = "https://github.com/gauteh/hidefix"
 description = "Concurrent HDF5 and NetCDF4 reader (experimental)"


### PR DESCRIPTION
Aligns the Cargo.toml license field with the repository's MIT LICENSE file, per #48.